### PR TITLE
3: Refactor the models, dataset, and trainer hparams for autoyahp

### DIFF
--- a/composer/datasets/c4.py
+++ b/composer/datasets/c4.py
@@ -11,6 +11,7 @@ import logging
 from dataclasses import dataclass
 from functools import partial
 from itertools import chain, cycle
+from typing import Optional
 
 import yahp as hp
 from torch.utils.data import DataLoader, IterableDataset, get_worker_info
@@ -50,13 +51,15 @@ class C4DatasetHparams(DatasetHparams):
         DataLoader: A PyTorch :class:`~torch.utils.data.DataLoader` object.
     """
 
-    split: str = hp.optional("What split of the dataset to use. Either `train` or `validation`.", default=None)
-    num_samples: int = hp.optional(
+    split: Optional[str] = hp.optional("What split of the dataset to use. Either `train` or `validation`.",
+                                       default=None)
+    num_samples: Optional[int] = hp.optional(
         "The number of post-processed token samples, used to set epoch size of the IterableDataset.", default=None)
-    tokenizer_name: str = hp.optional("The name of the HuggingFace tokenizer to preprocess text with.", default=None)
-    max_seq_len: int = hp.optional("The max sequence length of each token sample.", default=None)
-    group_method: str = hp.optional("How to group text samples into token samples. Either `truncate` or `concat`.",
-                                    default=None)
+    tokenizer_name: Optional[str] = hp.optional("The name of the HuggingFace tokenizer to preprocess text with.",
+                                                default=None)
+    max_seq_len: Optional[int] = hp.optional("The max sequence length of each token sample.", default=None)
+    group_method: Optional[str] = hp.optional(
+        "How to group text samples into token samples. Either `truncate` or `concat`.", default=None)
     mlm: bool = hp.optional("Whether or not to use masked language modeling.", default=False)
     mlm_probability: float = hp.optional("If `mlm=True`, the probability that tokens are masked.", default=0.15)
     shuffle: bool = hp.optional(

--- a/composer/datasets/cifar.py
+++ b/composer/datasets/cifar.py
@@ -195,8 +195,8 @@ class CIFARWebDatasetHparams(WebDatasetHparams):
     height: int = hp.optional('Image height', default=32)
     width: int = hp.optional('Image width', default=32)
     n_classes: int = hp.optional('Number of output classes', default=0)
-    channel_means: List[float] = hp.optional('Mean per image channel', default=(0, 0, 0))
-    channel_stds: List[float] = hp.optional('Std per image channel', default=(0, 0, 0))
+    channel_means: List[float] = hp.optional('Mean per image channel', default_factory=lambda: [0, 0, 0])
+    channel_stds: List[float] = hp.optional('Std per image channel', default_factory=lambda: [0, 0, 0])
 
     def initialize_object(self, batch_size: int, dataloader_hparams: DataLoaderHparams):
         from composer.datasets.webdataset_utils import load_webdataset
@@ -246,8 +246,8 @@ class CIFAR10WebDatasetHparams(CIFARWebDatasetHparams):
     n_train_samples: int = hp.optional('Number of samples in training split', default=50_000)
     n_val_samples: int = hp.optional('Number of samples in validation split', default=10_000)
     n_classes: int = hp.optional('Number of output classes', default=10)
-    channel_means: List[float] = hp.optional('Mean per image channel', default=(0.4914, 0.4822, 0.4465))
-    channel_stds: List[float] = hp.optional('Std per image channel', default=(0.247, 0.243, 0.261))
+    channel_means: List[float] = hp.optional('Mean per image channel', default_factory=lambda: [0.4914, 0.4822, 0.4465])
+    channel_stds: List[float] = hp.optional('Std per image channel', default_factory=lambda: [0.247, 0.243, 0.261])
 
 
 @dataclass
@@ -270,8 +270,8 @@ class CIFAR20WebDatasetHparams(CIFARWebDatasetHparams):
     n_train_samples: int = hp.optional('Number of samples in training split', default=50_000)
     n_val_samples: int = hp.optional('Number of samples in validation split', default=10_000)
     n_classes: int = hp.optional('Number of output classes', default=20)
-    channel_means: List[float] = hp.optional('Mean per image channel', default=(0.5071, 0.4867, 0.4408))
-    channel_stds: List[float] = hp.optional('Std per image channel', default=(0.2675, 0.2565, 0.2761))
+    channel_means: List[float] = hp.optional('Mean per image channel', default_factory=lambda: [0.5071, 0.4867, 0.4408])
+    channel_stds: List[float] = hp.optional('Std per image channel', default_factory=lambda: [0.2675, 0.2565, 0.2761])
 
 
 @dataclass
@@ -294,5 +294,5 @@ class CIFAR100WebDatasetHparams(CIFARWebDatasetHparams):
     n_train_samples: int = hp.optional('Number of samples in training split', default=50_000)
     n_val_samples: int = hp.optional('Number of samples in validation split', default=10_000)
     n_classes: int = hp.optional('Number of output classes', default=100)
-    channel_means: List[float] = hp.optional('Mean per image channel', default=(0.5071, 0.4867, 0.4408))
-    channel_stds: List[float] = hp.optional('Std per image channel', default=(0.2675, 0.2565, 0.2761))
+    channel_means: List[float] = hp.optional('Mean per image channel', default_factory=lambda: [0.5071, 0.4867, 0.4408])
+    channel_stds: List[float] = hp.optional('Std per image channel', default_factory=lambda: [0.2675, 0.2565, 0.2761])

--- a/composer/datasets/glue.py
+++ b/composer/datasets/glue.py
@@ -18,7 +18,7 @@ Please refer to the `GLUE`_ benchmark for more details.
 
 import logging
 from dataclasses import dataclass
-from typing import cast
+from typing import Optional, cast
 
 import yahp as hp
 from torch.utils.data import DataLoader
@@ -64,10 +64,11 @@ class GLUEHparams(DatasetHparams, SyntheticHparamsMixin):
         DataLoader: A PyTorch :class:`~torch.utils.data.DataLoader` object.
     """
 
-    task: str = hp.optional(
+    task: Optional[str] = hp.optional(
         "The GLUE task to train on, choose one from: CoLA, MNLI, MRPC, QNLI, QQP, RTE, SST-2, and STS-B.", default=None)
-    tokenizer_name: str = hp.optional("The name of the HuggingFace tokenizer to preprocess text with.", default=None)
-    split: str = hp.optional("Whether to use 'train', 'validation' or 'test' split.", default=None)
+    tokenizer_name: Optional[str] = hp.optional("The name of the HuggingFace tokenizer to preprocess text with.",
+                                                default=None)
+    split: Optional[str] = hp.optional("Whether to use 'train', 'validation' or 'test' split.", default=None)
     max_seq_length: int = hp.optional(
         default=256, doc='Optionally, the ability to set a custom sequence length for the training dataset.')
     max_network_retries: int = hp.optional(default=10,
@@ -95,6 +96,9 @@ class GLUEHparams(DatasetHparams, SyntheticHparamsMixin):
             raise MissingConditionalImportError(extra_deps_group="nlp", conda_package="transformers") from e
 
         self.validate()
+        assert self.task is not None, "checked in validate()"
+        assert self.tokenizer_name is not None, "checked in validate()"
+
         if self.use_synthetic:
             column_names = [i for i in _task_to_keys[self.task] if i is not None]
 

--- a/composer/datasets/imagenet.py
+++ b/composer/datasets/imagenet.py
@@ -319,8 +319,8 @@ class TinyImagenet200WebDatasetHparams(WebDatasetHparams):
     height: int = hp.optional('Image height', default=64)
     width: int = hp.optional('Image width', default=64)
     n_classes: int = hp.optional('Number of output classes', default=200)
-    channel_means: List[float] = hp.optional('Mean per image channel', default=(0.485, 0.456, 0.406))
-    channel_stds: List[float] = hp.optional('Std per image channel', default=(0.229, 0.224, 0.225))
+    channel_means: List[float] = hp.optional('Mean per image channel', default_factory=lambda: [0.485, 0.456, 0.406])
+    channel_stds: List[float] = hp.optional('Std per image channel', default_factory=lambda: [0.229, 0.224, 0.225])
 
     def initialize_object(self, batch_size: int, dataloader_hparams: DataLoaderHparams) -> DataSpec:
         from composer.datasets.webdataset_utils import load_webdataset

--- a/composer/datasets/lm_datasets.py
+++ b/composer/datasets/lm_datasets.py
@@ -57,7 +57,7 @@ class LMDatasetHparams(DatasetHparams, SyntheticHparamsMixin):
     split: Optional[str] = hp.optional("Whether to use 'train', 'validation' or 'test' split.", default=None)
     tokenizer_name: Optional[str] = hp.optional("The name of the tokenizer to preprocess text with.", default=None)
     use_masked_lm: bool = hp.optional("Whether the dataset should be encoded with masked language modeling or not.",
-                                      default=None)
+                                      default=False)
     num_tokens: int = hp.optional(doc='If desired, the number of tokens to truncate the dataset to.', default=0)
     mlm_probability: float = hp.optional("If using masked language modeling, the probability to mask tokens with.",
                                          default=0.15)

--- a/composer/models/resnet/resnet_hparams.py
+++ b/composer/models/resnet/resnet_hparams.py
@@ -32,7 +32,6 @@ class ResNetHparams(ModelHparams):
     model_name: str = hp.optional(
         f"ResNet architecture to instantiate, must be one of {ComposerResNet.valid_model_names}. (default: '')",
         default='')
-    num_classes: int = hp.optional("Number of classes for the classification taks. (default: ``None``)", default=None)
     pretrained: bool = hp.optional("If true, use ImageNet pretrained weights. (default: ``False``)", default=False)
     groups: int = hp.optional(
         "Number of filter groups for the 3x3 convolution layer in bottleneck block. (default: ``1``)", default=1)
@@ -50,6 +49,8 @@ class ResNetHparams(ModelHparams):
             raise ValueError("num_classes must be specified")
 
     def initialize_object(self):
+        if self.num_classes is None:
+            raise ValueError("num_classes must be specified")
         return ComposerResNet(model_name=self.model_name,
                               num_classes=self.num_classes,
                               pretrained=self.pretrained,

--- a/composer/models/resnet_cifar/resnet_cifar_hparams.py
+++ b/composer/models/resnet_cifar/resnet_cifar_hparams.py
@@ -4,6 +4,7 @@
 """`YAHP <https://docs.mosaicml.com/projects/yahp/en/stable/README.html>`_ interface for
 :class:`.ComposerResNetCIFAR`."""
 from dataclasses import dataclass
+from typing import Optional
 
 import yahp as hp
 
@@ -22,7 +23,7 @@ class ResNetCIFARHparams(ModelHparams):
         num_classes (int, optional): The number of classes. Needed for classification tasks. Default: ``10``.
         initializers (List[Initializer], optional): Initializers for the model. ``None`` for no initialization. Default: ``None``.
     """
-    model_name: str = hp.optional('"cifar_resnet_9", "cifar_resnet_20" or "cifar_resnet_56"', default=None)
+    model_name: Optional[str] = hp.optional('"cifar_resnet_9", "cifar_resnet_20" or "cifar_resnet_56"', default=None)
     num_classes: int = hp.optional("The number of classes.  Needed for classification tasks", default=10)
 
     def validate(self):
@@ -30,6 +31,8 @@ class ResNetCIFARHparams(ModelHparams):
             raise ValueError('model name must be one of "cifar_resnet_9", "cifar_resnet_20" or "cifar_resnet_56".')
 
     def initialize_object(self):
+        if self.model_name is None:
+            raise ValueError('model name must be one of "cifar_resnet_9", "cifar_resnet_20" or "cifar_resnet_56".')
         return ComposerResNetCIFAR(model_name=self.model_name,
                                    num_classes=self.num_classes,
                                    initializers=self.initializers)

--- a/composer/models/ssd/hparams.yaml
+++ b/composer/models/ssd/hparams.yaml
@@ -12,7 +12,7 @@ val_dataset:
     download: false
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   sgd:
     lr: 0.08
     weight_decay: 5e-4
@@ -36,8 +36,6 @@ eval_batch_size: 1024
 seed: 0
 eval_interval: 10ep
 grad_accum: 1
-device:
-  gpu: {}
 max_duration: 80ep
 dataloader:
   pin_memory: true
@@ -45,4 +43,3 @@ dataloader:
   prefetch_factor: 2
   persistent_workers: true
   num_workers: 8
-precision: amp

--- a/composer/models/timm/timm_hparams.py
+++ b/composer/models/timm/timm_hparams.py
@@ -33,7 +33,7 @@ class TimmHparams(ModelHparams):
         bn_eps (float, optional): BatchNorm epsilon override (model default if ``None``). Default: ``None``.
     """
 
-    model_name: str = hp.optional(
+    model_name: Optional[str] = hp.optional(
         textwrap.dedent("""\
         timm model name e.g: 'resnet50', list of models can be found at
         https://github.com/rwightman/pytorch-image-models"""),
@@ -60,6 +60,8 @@ class TimmHparams(ModelHparams):
             raise ValueError(f"model must be one of {timm.models.list_models()}")
 
     def initialize_object(self):
+        if self.model_name is None:
+            raise ValueError("model_name must be specified")
         return Timm(model_name=self.model_name,
                     pretrained=self.pretrained,
                     num_classes=self.num_classes,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -489,7 +489,7 @@ class Trainer:
                 trainer.engine.close()
         load_weights_only (bool, optional): Whether or not to only restore the weights from the checkpoint without
             restoring the associated state. Ignored if ``load_path`` is ``None``. (default: ``False``)
-        load_strict (bool, optional): Ensure that the set of weights in the checkpoint and model must exactly match.
+        load_strict_model_weights (bool, optional): Ensure that the set of weights in the checkpoint and model must exactly match.
             Ignored if ``load_path`` is ``None``. (default: ``False``)
         load_chunk_size (int, optional): Chunk size (in bytes) to use when downloading checkpoints.
             Ignored if ``load_path`` is either ``None`` or a local file path. (default: ``1,048,675``)
@@ -670,7 +670,7 @@ class Trainer:
         load_path: Optional[str] = None,
         load_object_store: Optional[Union[ObjectStore, LoggerDestination]] = None,
         load_weights_only: bool = False,
-        load_strict: bool = False,
+        load_strict_model_weights: bool = False,
         load_chunk_size: int = 1_048_576,
         load_progress_bar: bool = True,
 
@@ -944,7 +944,7 @@ class Trainer:
                                               path=load_path,
                                               object_store=load_object_store,
                                               load_weights_only=load_weights_only,
-                                              strict_model_weights=load_strict,
+                                              strict_model_weights=load_strict_model_weights,
                                               chunk_size=load_chunk_size,
                                               progress_bar=load_progress_bar)
             log.info(f"Setting seed to {self.state.seed}")

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -305,7 +305,7 @@ class TrainerHparams(hp.Hparams):
 
     hparams_registry = {  # type: ignore
         "algorithms": algorithms_registry,
-        "optimizer": optimizer_registry,
+        "optimizers": optimizer_registry,
         "schedulers": scheduler_registry,
         "loggers": logger_registry,
         "load_logger_destination": logger_registry,
@@ -350,7 +350,7 @@ class TrainerHparams(hp.Hparams):
     algorithms: List[AlgorithmHparams] = hp.optional(doc="Algorithms", default_factory=list)
 
     # Optimizer and Scheduler
-    optimizer: Optional[OptimizerHparams] = hp.optional(doc="Optimizer to use", default=None)
+    optimizers: Optional[OptimizerHparams] = hp.optional(doc="Optimizer to use", default=None)
     schedulers: List[SchedulerHparams] = hp.optional(doc="Schedulers", default_factory=list)
     scale_schedule_ratio: float = hp.optional(
         doc="Ratio by which to scale the training duration and learning rate schedules.",
@@ -463,7 +463,7 @@ class TrainerHparams(hp.Hparams):
                                    default=False)
 
     # DeepSpeed
-    deepspeed: Optional[Dict[str, JSON]] = hp.optional(doc="Configuration for DeepSpeed.", default=None)
+    deepspeed_config: Optional[Dict[str, JSON]] = hp.optional(doc="Configuration for DeepSpeed.", default=None)
 
     # System/Numerics
     device: Optional[DeviceHparams] = hp.optional(doc="Device Parameters", default=None)
@@ -508,11 +508,11 @@ class TrainerHparams(hp.Hparams):
     def validate(self):
         super().validate()
 
-        if self.deepspeed is not None:
-            self.deepspeed["steps_per_print"] = cast(int, self.deepspeed.get("steps_per_print", 1e20))
+        if self.deepspeed_config is not None:
+            self.deepspeed_config["steps_per_print"] = cast(int, self.deepspeed_config.get("steps_per_print", 1e20))
 
-            if "zero_optimization" in self.deepspeed:
-                zero_stage = cast(dict, self.deepspeed["zero_optimization"]).get("stage", 0)
+            if "zero_optimization" in self.deepspeed_config:
+                zero_stage = cast(dict, self.deepspeed_config["zero_optimization"]).get("stage", 0)
             else:
                 zero_stage = 0
 
@@ -597,7 +597,7 @@ class TrainerHparams(hp.Hparams):
         )
 
         # Optimizers and Schedulers
-        optimizer = self.optimizer.initialize_object(model.parameters()) if self.optimizer is not None else None
+        optimizer = self.optimizers.initialize_object(model.parameters()) if self.optimizers is not None else None
         schedulers = [scheduler.initialize_object() for scheduler in self.schedulers]
 
         load_object_store = None
@@ -652,7 +652,7 @@ class TrainerHparams(hp.Hparams):
             load_path=self.load_path,
             load_object_store=load_object_store,
             load_weights_only=self.load_weights_only,
-            load_strict=self.load_strict_model_weights,
+            load_strict_model_weights=self.load_strict_model_weights,
             load_chunk_size=self.load_chunk_size,
             load_progress_bar=self.load_progress_bar,
 
@@ -670,7 +670,7 @@ class TrainerHparams(hp.Hparams):
             autoresume=self.autoresume,
 
             # DeepSpeed
-            deepspeed_config=self.deepspeed,
+            deepspeed_config=self.deepspeed_config,
 
             # System/Numerics
             device=device,

--- a/composer/yamls/models/bert-base.yaml
+++ b/composer/yamls/models/bert-base.yaml
@@ -37,7 +37,7 @@ model:
     use_pretrained: false
     tokenizer_name: bert-base-uncased
     pretrained_model_name: bert-base-uncased
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 5.0e-4
     betas:
@@ -52,8 +52,6 @@ max_duration: 256_000_000
 train_batch_size: 4000
 eval_batch_size: 2000
 seed: 19
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
@@ -61,5 +59,4 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 grad_accum: 2
-precision: amp
 eval_interval: 1000ba

--- a/composer/yamls/models/classify_mnist.yaml
+++ b/composer/yamls/models/classify_mnist.yaml
@@ -12,7 +12,7 @@ val_dataset:
     download: true
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   sgd:
     lr: 0.1
     momentum: 0.9
@@ -29,8 +29,6 @@ max_duration: 10ep
 train_batch_size: 2048
 eval_batch_size: 1000
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -38,4 +36,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/classify_mnist_cpu.yaml
+++ b/composer/yamls/models/classify_mnist_cpu.yaml
@@ -12,7 +12,7 @@ val_dataset:
     download: true
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   sgd:
     lr: 0.1
     momentum: 0.9
@@ -29,8 +29,6 @@ max_duration: 10ep
 train_batch_size: 2048
 eval_batch_size: 1000
 seed: 42
-device:
-  cpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -38,4 +36,3 @@ dataloader:
   persistent_workers: true
   num_workers: 1
 grad_accum: 1
-precision: fp32

--- a/composer/yamls/models/deeplabv3_ade20k_optimized.yaml
+++ b/composer/yamls/models/deeplabv3_ade20k_optimized.yaml
@@ -14,7 +14,7 @@ val_dataset:
     final_size: 512
     drop_last: false
     shuffle: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 0.01
     momentum: 0.9
@@ -39,8 +39,6 @@ max_duration: 128ep
 train_batch_size: 32
 eval_batch_size: 32
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -48,5 +46,4 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp
 dist_timeout: 60

--- a/composer/yamls/models/deeplabv3_ade20k_unoptimized.yaml
+++ b/composer/yamls/models/deeplabv3_ade20k_unoptimized.yaml
@@ -14,7 +14,7 @@ val_dataset:
     final_size: 512
     drop_last: false
     shuffle: false
-optimizer:
+optimizers:
   sgd:
     lr: 0.01
     momentum: 0.9
@@ -40,8 +40,6 @@ max_duration: 127ep
 train_batch_size: 16
 eval_batch_size: 16
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -49,5 +47,4 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp
 dist_timeout: 60

--- a/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
+++ b/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
@@ -20,7 +20,7 @@ val_dataset:
     ignore_background: true
     drop_last: false
     shuffle: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 0.01
     momentum: 0.9
@@ -45,8 +45,6 @@ max_duration: 128ep
 train_batch_size: 32
 eval_batch_size: 32
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -54,5 +52,4 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp
 dist_timeout: 60

--- a/composer/yamls/models/deeplabv3_wds_ade20k_optimized.yaml
+++ b/composer/yamls/models/deeplabv3_wds_ade20k_optimized.yaml
@@ -14,7 +14,7 @@ val_dataset:
     final_size: 512
     drop_last: false
     shuffle: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 0.01
     momentum: 0.9
@@ -39,8 +39,6 @@ max_duration: 128ep
 train_batch_size: 32
 eval_batch_size: 32
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -48,5 +46,4 @@ dataloader:
   persistent_workers: true
   num_workers: 6
 grad_accum: 1
-precision: amp
 dist_timeout: 60

--- a/composer/yamls/models/efficientnetb0.yaml
+++ b/composer/yamls/models/efficientnetb0.yaml
@@ -14,7 +14,7 @@ val_dataset:
     datadir: /datasets/ImageNet
     shuffle: False
     drop_last: False
-optimizer:
+optimizers:
   rmsprop:
     lr: 0.08
     momentum: 0.9
@@ -32,8 +32,6 @@ max_duration: 400ep
 train_batch_size: 4096
 eval_batch_size: 2048
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -41,4 +39,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/glue/cola.yaml
+++ b/composer/yamls/models/glue/cola.yaml
@@ -25,7 +25,7 @@ model:
     use_pretrained: true
     tokenizer_name: bert-base-uncased
     pretrained_model_name: bert-base-uncased
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 5.0e-5
     betas:
@@ -40,8 +40,6 @@ max_duration: 10ep
 train_batch_size: 32
 eval_batch_size: 32
 seed: 19
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
@@ -49,7 +47,6 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 grad_accum: 1
-precision: amp
 eval_interval: 250ba
 callbacks:
   - lr_monitor: {}

--- a/composer/yamls/models/glue/mnli.yaml
+++ b/composer/yamls/models/glue/mnli.yaml
@@ -37,7 +37,7 @@ model:
     use_pretrained: true
     tokenizer_name: bert-base-uncased
     pretrained_model_name: bert-base-uncased
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 5.0e-5
     betas:
@@ -52,8 +52,6 @@ max_duration: 3ep
 train_batch_size: 48
 eval_batch_size: 48
 seed: 19
-device:
-  gpu: {}
 loggers:
   wandb: {}
 dataloader:
@@ -63,7 +61,6 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 grad_accum: 1
-precision: amp
 eval_interval: 2300ba
 callbacks:
   - lr_monitor: {}

--- a/composer/yamls/models/glue/mrpc.yaml
+++ b/composer/yamls/models/glue/mrpc.yaml
@@ -26,7 +26,7 @@ model:
     use_pretrained: true
     tokenizer_name: bert-base-uncased
     pretrained_model_name: bert-base-uncased
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 8.0e-5
     betas:
@@ -41,8 +41,6 @@ max_duration: 10ep
 train_batch_size: 32
 eval_batch_size: 32
 seed: 19
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
@@ -50,7 +48,6 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 grad_accum: 1
-precision: amp
 eval_interval: 100ba
 callbacks:
   - lr_monitor: {}

--- a/composer/yamls/models/glue/qnli.yaml
+++ b/composer/yamls/models/glue/qnli.yaml
@@ -25,7 +25,7 @@ model:
     use_pretrained: true
     tokenizer_name: bert-base-uncased
     pretrained_model_name: bert-base-uncased
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 1.0e-5
     betas:
@@ -40,8 +40,6 @@ max_duration: 10ep
 train_batch_size: 16
 eval_batch_size: 16
 seed: 19
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
@@ -49,7 +47,6 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 grad_accum: 1
-precision: amp
 eval_interval: 1000ba
 callbacks:
   - lr_monitor: {}

--- a/composer/yamls/models/glue/qqp.yaml
+++ b/composer/yamls/models/glue/qqp.yaml
@@ -26,7 +26,7 @@ model:
     use_pretrained: true
     tokenizer_name: bert-base-uncased
     pretrained_model_name: bert-base-uncased
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 3.0e-5
     betas:
@@ -41,8 +41,6 @@ max_duration: 5ep
 train_batch_size: 16
 eval_batch_size: 16
 seed: 19
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
@@ -50,7 +48,6 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 grad_accum: 1
-precision: amp
 eval_interval: 2000ba
 callbacks:
   - lr_monitor: {}

--- a/composer/yamls/models/glue/rte.yaml
+++ b/composer/yamls/models/glue/rte.yaml
@@ -25,7 +25,7 @@ model:
     use_pretrained: true
     tokenizer_name: bert-base-uncased
     pretrained_model_name: bert-base-uncased
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 1.0e-5
     betas:
@@ -40,8 +40,6 @@ max_duration: 3ep
 train_batch_size: 16
 eval_batch_size: 16
 seed: 19
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
@@ -49,7 +47,6 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 grad_accum: 1
-precision: amp
 eval_interval: 1000ba
 callbacks:
   - lr_monitor: {}

--- a/composer/yamls/models/glue/sst-2.yaml
+++ b/composer/yamls/models/glue/sst-2.yaml
@@ -25,7 +25,7 @@ model:
     use_pretrained: true
     tokenizer_name: bert-base-uncased
     pretrained_model_name: bert-base-uncased
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 3.0e-5
     betas:
@@ -40,8 +40,6 @@ max_duration: 3ep
 train_batch_size: 16
 eval_batch_size: 16
 seed: 19
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
@@ -49,7 +47,6 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 grad_accum: 1
-precision: amp
 eval_interval: 500ba
 callbacks:
   - lr_monitor: {}

--- a/composer/yamls/models/glue/stsb.yaml
+++ b/composer/yamls/models/glue/stsb.yaml
@@ -25,7 +25,7 @@ model:
     use_pretrained: true
     tokenizer_name: bert-base-uncased
     pretrained_model_name: bert-base-uncased
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 3.0e-5
     betas:
@@ -40,8 +40,6 @@ max_duration: 10ep
 train_batch_size: 32
 eval_batch_size: 32
 seed: 19
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
@@ -49,7 +47,6 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 grad_accum: 1
-precision: amp
 eval_interval: 200ba
 callbacks:
   - lr_monitor: {}

--- a/composer/yamls/models/gpt2_1,3b.yaml
+++ b/composer/yamls/models/gpt2_1,3b.yaml
@@ -53,7 +53,7 @@ model:
       transformers_version: 4.11.0.dev0
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   adamw:
     lr: 2.0e-4
     betas:
@@ -68,15 +68,12 @@ max_duration: 1ep
 train_batch_size: 1024
 eval_batch_size: 8
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 8
   timeout: 0
   prefetch_factor: 2
-precision: amp
 grad_clip_norm: 1.0
 grad_accum: 128
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt2_125m.yaml
+++ b/composer/yamls/models/gpt2_125m.yaml
@@ -55,7 +55,7 @@ model:
       transformers_version: 4.11.0.dev0
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   adamw:
     lr: 6.0e-4
     betas:
@@ -70,15 +70,12 @@ max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 8 # use micro_bs_per_gpu = 1 to accomodate 10GB limit
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 8
   timeout: 0
   prefetch_factor: 2
-precision: amp
 grad_clip_norm: 1.0
 grad_accum: 22
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt2_13b.yaml
+++ b/composer/yamls/models/gpt2_13b.yaml
@@ -53,7 +53,7 @@ model:
       transformers_version: 4.11.0.dev0
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   adamw:
     lr: 1.0e-4
     betas:
@@ -68,15 +68,12 @@ max_duration: 1ep
 train_batch_size: 2048
 eval_batch_size: 8
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 8
   timeout: 0
   prefetch_factor: 2
-precision: amp
 grad_clip_norm: 1.0
 grad_accum: 256
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt2_2,7b.yaml
+++ b/composer/yamls/models/gpt2_2,7b.yaml
@@ -53,7 +53,7 @@ model:
       transformers_version: 4.11.0.dev0
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   adamw:
     lr: 1.6e-4
     betas:
@@ -68,15 +68,12 @@ max_duration: 1ep
 train_batch_size: 1024
 eval_batch_size: 8
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 8
   timeout: 0
   prefetch_factor: 2
-precision: amp
 grad_clip_norm: 1.0
 grad_accum: 128
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt2_350m.yaml
+++ b/composer/yamls/models/gpt2_350m.yaml
@@ -53,7 +53,7 @@ model:
       transformers_version: 4.11.0.dev0
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   adamw:
     lr: 3.0e-4
     betas:
@@ -68,15 +68,12 @@ max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 8
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 8
   timeout: 0
   prefetch_factor: 2
-precision: amp
 grad_clip_norm: 1.0
 grad_accum: 64
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt2_52m.yaml
+++ b/composer/yamls/models/gpt2_52m.yaml
@@ -55,7 +55,7 @@ model:
       transformers_version: 4.11.0.dev0
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   adamw:
     lr: 1.5e-3
     betas:
@@ -70,15 +70,12 @@ max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 16 # use micro_bs_per_gpu = 2 to accomodate 10GB limit
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 8
   timeout: 0
   prefetch_factor: 2
-precision: amp
 grad_clip_norm: 1.0
 grad_accum: 11
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt2_6,7b.yaml
+++ b/composer/yamls/models/gpt2_6,7b.yaml
@@ -53,7 +53,7 @@ model:
       transformers_version: 4.11.0.dev0
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   adamw:
     lr: 1.2e-4
     betas:
@@ -68,15 +68,12 @@ max_duration: 1ep
 train_batch_size: 2048
 eval_batch_size: 8
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 8
   timeout: 0
   prefetch_factor: 2
-precision: amp
 grad_clip_norm: 1.0
 grad_accum: 256
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt2_760m.yaml
+++ b/composer/yamls/models/gpt2_760m.yaml
@@ -53,7 +53,7 @@ model:
       transformers_version: 4.11.0.dev0
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   adamw:
     lr: 2.5e-4
     betas:
@@ -68,15 +68,12 @@ max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 8
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 8
   timeout: 0
   prefetch_factor: 2
-precision: amp
 grad_clip_norm: 1.0
 grad_accum: 64
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt2_83m.yaml
+++ b/composer/yamls/models/gpt2_83m.yaml
@@ -55,7 +55,7 @@ model:
       transformers_version: 4.11.0.dev0
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   adamw:
     lr: 1.0e-3
     betas:
@@ -70,15 +70,12 @@ max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 16 # use micro_bs_per_gpu = 2 to accomodate 10GB limit
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 8
   timeout: 0
   prefetch_factor: 2
-precision: amp
 grad_clip_norm: 1.0
 grad_accum: 16
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt3_125m.yaml
+++ b/composer/yamls/models/gpt3_125m.yaml
@@ -52,7 +52,7 @@ model:
       transformers_version: 4.16.2
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 6.0e-4
     betas:
@@ -68,17 +68,14 @@ train_batch_size: 256 # 0.5e6 tok ~= 256[bs] * 2048[msl]
 grad_accum: 8 # 256[bs] / 8[devices] / 4[per_gpu_microbatch_size] = 8[ga], assuming 8xA100-40GB
 eval_batch_size: 32 # 32[bs] / 8[devices] = 4[per_gpu_microbatch_size], assuming 8xA100-40GB
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 1
   timeout: 0
   prefetch_factor: 2
-deepspeed:
+deepspeed_config:
   zero_optimization:
     stage: 0
-precision: fp16
 grad_clip_norm: 1.0
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt3_350m.yaml
+++ b/composer/yamls/models/gpt3_350m.yaml
@@ -52,7 +52,7 @@ model:
       transformers_version: 4.16.2
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 3.0e-4
     betas:
@@ -68,17 +68,14 @@ train_batch_size: 256 # 0.5e6 tok ~= 256[bs] * 2048[msl]
 grad_accum: 16 # 256[bs] / 8[devices] / 2[per_gpu_microbatch_size] = 16[ga], assuming 8xA100-40GB
 eval_batch_size: 16 # 16[bs] / 8[devices] = 2[per_gpu_microbatch_size], assuming 8xA100-40GB
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 1
   timeout: 0
   prefetch_factor: 2
-deepspeed:
+deepspeed_config:
   zero_optimization:
     stage: 0
-precision: fp16
 grad_clip_norm: 1.0
 eval_interval: 1000ba

--- a/composer/yamls/models/gpt3_760m.yaml
+++ b/composer/yamls/models/gpt3_760m.yaml
@@ -52,7 +52,7 @@ model:
       transformers_version: 4.16.2
       use_cache: true
       vocab_size: 50257
-optimizer:
+optimizers:
   decoupled_adamw:
     lr: 2.5e-4
     betas:
@@ -68,17 +68,14 @@ train_batch_size: 256 # 0.5e6 tok ~= 256[bs] * 2048[msl]
 grad_accum: 32 # 256[bs] / 8[devices] / 1[per_gpu_microbatch_size] = 32[ga], assuming 8xA100-40GB
 eval_batch_size: 8 # 8[bs] / 8[devices] = 1[per_gpu_microbatch_size], assuming 8xA100-40GB
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   persistent_workers: true
   num_workers: 1
   timeout: 0
   prefetch_factor: 2
-deepspeed:
+deepspeed_config:
   zero_optimization:
     stage: 0
-precision: fp16
 grad_clip_norm: 1.0
 eval_interval: 1000ba

--- a/composer/yamls/models/resnet101.yaml
+++ b/composer/yamls/models/resnet101.yaml
@@ -14,7 +14,7 @@ val_dataset:
     datadir: /datasets/ImageNet
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -35,8 +35,6 @@ max_duration: 90ep
 train_batch_size: 2048
 eval_batch_size: 2048
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -44,4 +42,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 2
-precision: amp

--- a/composer/yamls/models/resnet101_synthetic.yaml
+++ b/composer/yamls/models/resnet101_synthetic.yaml
@@ -14,7 +14,7 @@ val_dataset:
     use_synthetic: true
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -37,8 +37,6 @@ eval_batch_size: 2048
 train_subset_num_batches: 10
 eval_subset_num_batches: 10
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -46,4 +44,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 2
-precision: amp

--- a/composer/yamls/models/resnet152.yaml
+++ b/composer/yamls/models/resnet152.yaml
@@ -14,7 +14,7 @@ val_dataset:
     datadir: /datasets/ImageNet
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -35,8 +35,6 @@ max_duration: 90ep
 train_batch_size: 2048
 eval_batch_size: 2048
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -44,4 +42,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet152_synthetic.yaml
+++ b/composer/yamls/models/resnet152_synthetic.yaml
@@ -14,7 +14,7 @@ val_dataset:
     use_synthetic: true
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -37,8 +37,6 @@ eval_batch_size: 2048
 train_subset_num_batches: 10
 eval_subset_num_batches: 10
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -46,4 +44,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet18.yaml
+++ b/composer/yamls/models/resnet18.yaml
@@ -14,7 +14,7 @@ val_dataset:
     datadir: /datasets/ImageNet
     shuffle: true
     drop_last: true
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -35,8 +35,6 @@ max_duration: 90ep
 train_batch_size: 2048
 eval_batch_size: 1000
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -44,4 +42,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet18_synthetic.yaml
+++ b/composer/yamls/models/resnet18_synthetic.yaml
@@ -14,7 +14,7 @@ val_dataset:
     use_synthetic: true
     shuffle: true
     drop_last: true
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -37,8 +37,6 @@ eval_batch_size: 1000
 train_subset_num_batches: 10
 eval_subset_num_batches: 10
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -46,4 +44,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet20_cifar10.yaml
+++ b/composer/yamls/models/resnet20_cifar10.yaml
@@ -12,7 +12,7 @@ val_dataset:
     download: false
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 1.2
     momentum: 0.9
@@ -35,12 +35,9 @@ train_batch_size: 1024
 eval_batch_size: 1000
 seed: 17
 grad_accum: 1
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
   prefetch_factor: 2
   persistent_workers: true
   num_workers: 8
-precision: amp

--- a/composer/yamls/models/resnet34.yaml
+++ b/composer/yamls/models/resnet34.yaml
@@ -14,7 +14,7 @@ val_dataset:
     datadir: /datasets/ImageNet
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -35,8 +35,6 @@ max_duration: 90ep
 train_batch_size: 2048
 eval_batch_size: 2048
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -44,4 +42,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet34_synthetic.yaml
+++ b/composer/yamls/models/resnet34_synthetic.yaml
@@ -14,7 +14,7 @@ val_dataset:
     use_synthetic: true
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -37,8 +37,6 @@ eval_batch_size: 2048
 train_subset_num_batches: 10
 eval_subset_num_batches: 10
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -46,4 +44,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet50.yaml
+++ b/composer/yamls/models/resnet50.yaml
@@ -14,7 +14,7 @@ val_dataset:
     datadir: /datasets/ImageNet
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -35,8 +35,6 @@ max_duration: 90ep
 train_batch_size: 2048
 eval_batch_size: 2048
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -44,4 +42,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet50_streaming.yaml
+++ b/composer/yamls/models/resnet50_streaming.yaml
@@ -16,7 +16,7 @@ val_dataset:
     crop_size: 224
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -37,8 +37,6 @@ max_duration: 90ep
 train_batch_size: 2048
 eval_batch_size: 2048
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -46,4 +44,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet50_synthetic.yaml
+++ b/composer/yamls/models/resnet50_synthetic.yaml
@@ -14,7 +14,7 @@ val_dataset:
     use_synthetic: true
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -37,8 +37,6 @@ eval_batch_size: 2048
 train_subset_num_batches: 10
 eval_subset_num_batches: 10
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -46,4 +44,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet50_webdataset.yaml
+++ b/composer/yamls/models/resnet50_webdataset.yaml
@@ -12,7 +12,7 @@ val_dataset:
     is_train: false
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -33,8 +33,6 @@ max_duration: 90ep
 train_batch_size: 2048
 eval_batch_size: 2048
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -42,4 +40,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/resnet56_cifar10.yaml
+++ b/composer/yamls/models/resnet56_cifar10.yaml
@@ -12,7 +12,7 @@ val_dataset:
     download: false
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 1.2
     momentum: 0.9
@@ -35,12 +35,9 @@ train_batch_size: 1024
 eval_batch_size: 1000
 seed: 17
 grad_accum: 1
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
   prefetch_factor: 2
   persistent_workers: true
   num_workers: 8
-precision: amp

--- a/composer/yamls/models/resnet56_cifar10_synthetic.yaml
+++ b/composer/yamls/models/resnet56_cifar10_synthetic.yaml
@@ -12,7 +12,7 @@ val_dataset:
     download: false
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 1.2
     momentum: 0.9
@@ -37,12 +37,9 @@ train_subset_num_batches: 10
 eval_subset_num_batches: 10
 seed: 17
 grad_accum: 1
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
   prefetch_factor: 2
   persistent_workers: true
   num_workers: 8
-precision: amp

--- a/composer/yamls/models/resnet9_cifar10.yaml
+++ b/composer/yamls/models/resnet9_cifar10.yaml
@@ -14,7 +14,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     use_ffcv: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 1.2
     momentum: 0.9
@@ -37,12 +37,9 @@ train_batch_size: 1024
 eval_batch_size: 1000
 seed: 17
 grad_accum: 1
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
   prefetch_factor: 2
   persistent_workers: true
   num_workers: 8
-precision: amp

--- a/composer/yamls/models/timm_resnet50_imagenet.yaml
+++ b/composer/yamls/models/timm_resnet50_imagenet.yaml
@@ -14,7 +14,7 @@ val_dataset:
     datadir: /datasets/ImageNet
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   decoupled_sgdw:
     lr: 2.048
     momentum: 0.875
@@ -32,8 +32,6 @@ max_duration: 90ep
 train_batch_size: 2048
 eval_batch_size: 2048
 seed: 17
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -41,4 +39,3 @@ dataloader:
   persistent_workers: true
   num_workers: 8
 grad_accum: 1
-precision: amp

--- a/composer/yamls/models/timm_vit_small_patch16.yaml
+++ b/composer/yamls/models/timm_vit_small_patch16.yaml
@@ -14,7 +14,7 @@ val_dataset:
     datadir: /datasets/ImageNet
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   adamw:
     lr: 3e-3
     betas:
@@ -34,8 +34,6 @@ max_duration: 300ep
 train_batch_size: 4096
 eval_batch_size: 512
 seed: 1337
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -44,4 +42,3 @@ dataloader:
   num_workers: 8
 grad_accum: 8
 grad_clip_norm: 1.0
-precision: amp

--- a/composer/yamls/models/unet.yaml
+++ b/composer/yamls/models/unet.yaml
@@ -10,7 +10,7 @@ val_dataset:
     datadir: /datasets/01_2d
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   radam:
     lr: 0.001
     betas: [0.9, 0.999]
@@ -28,12 +28,9 @@ train_batch_size: 64
 eval_batch_size: 8
 seed: 0
 grad_accum: 1
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
   prefetch_factor: 2
   persistent_workers: true
   num_workers: 8
-precision: amp

--- a/composer/yamls/models/vit_small_patch16.yaml
+++ b/composer/yamls/models/vit_small_patch16.yaml
@@ -14,7 +14,7 @@ val_dataset:
     datadir: /datasets/ImageNet
     shuffle: false
     drop_last: false
-optimizer:
+optimizers:
   adamw:
     lr: 3e-3
     betas:
@@ -35,8 +35,6 @@ max_duration: 300ep
 train_batch_size: 4096
 eval_batch_size: 512
 seed: 1337
-device:
-  gpu: {}
 dataloader:
   pin_memory: true
   timeout: 0
@@ -45,4 +43,3 @@ dataloader:
   num_workers: 8
 grad_accum: 8
 grad_clip_norm: 1.0
-precision: amp

--- a/tests/algorithms/test_algorithm_resumption.py
+++ b/tests/algorithms/test_algorithm_resumption.py
@@ -94,7 +94,7 @@ def test_algorithm_resumption(
         model=copied_model,
         load_path=os.path.join(folder1, resume_file),
         load_weights_only=False,
-        load_strict=False,
+        load_strict_model_weights=False,
         optimizers=optimizer,
         schedulers=scheduler,
         save_folder=folder2,

--- a/tests/fixtures/dummy_fixtures.py
+++ b/tests/fixtures/dummy_fixtures.py
@@ -148,7 +148,7 @@ def composer_trainer_hparams(
 ) -> TrainerHparams:
     return TrainerHparams(
         algorithms=[],
-        optimizer=AdamHparams(),
+        optimizers=AdamHparams(),
         schedulers=[ExponentialSchedulerHparams(gamma=0.9)],
         max_duration="2ep",
         precision=Precision.FP32,

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -203,7 +203,7 @@ def test_load_weights(
     second_trainer_hparams.load_weights_only = True
     second_trainer_hparams.load_strict_model_weights = True
     # setup a new optimizer
-    second_trainer_hparams.optimizer = AdamWHparams()
+    second_trainer_hparams.optimizers = AdamWHparams()
 
     # setup a new LR scheduler
     assert isinstance(second_trainer_hparams.max_duration, str)
@@ -513,7 +513,7 @@ def test_checkpoint(
         composer_trainer_hparams.train_dataset = model_hparams.train_dataset
         composer_trainer_hparams.val_dataset = model_hparams.val_dataset
         composer_trainer_hparams.model = model_hparams.model
-        composer_trainer_hparams.optimizer = model_hparams.optimizer
+        composer_trainer_hparams.optimizers = model_hparams.optimizers
         composer_trainer_hparams.schedulers = model_hparams.schedulers
 
     if not isinstance(composer_trainer_hparams.train_dataset, SyntheticHparamsMixin):
@@ -554,7 +554,7 @@ def test_checkpoint(
                         Skipping test since deterministic mode is required for
                         non-trivial models, but deterministic mode isn't compatible with deepspeed
                         zero stage {zero_stage}"""))
-        composer_trainer_hparams.deepspeed = {"zero_optimization": {"stage": zero_stage}}
+        composer_trainer_hparams.deepspeed_config = {"zero_optimization": {"stage": zero_stage}}
 
     checkpoint_a_folder = str(tmp_path / "first")
     composer_trainer_hparams.save_folder = checkpoint_a_folder

--- a/tests/trainer/test_scale_schedule.py
+++ b/tests/trainer/test_scale_schedule.py
@@ -106,7 +106,7 @@ class TestScaleScheduleTrainer():
         composer_trainer_hparams: TrainerHparams,
     ):
 
-        composer_trainer_hparams.optimizer = SGDHparams(lr=1.0)
+        composer_trainer_hparams.optimizers = SGDHparams(lr=1.0)
         composer_trainer_hparams.max_duration = '10ep'
         composer_trainer_hparams.schedulers = [MultiStepSchedulerHparams(milestones=['30ba', '50ba'], gamma=0.1)]
 


### PR DESCRIPTION
1. Fixed bad hparam type annoations
2. Renamed fields in the trainer hparams and trainer to be consistent
3. Removed all device and precision settings from the hparams, as the trainer now uses reasonable defaults (gpu + amp if cuda is available; cpu + fp32 otherwise) -- no need to specify this manually